### PR TITLE
Make YAML operations more targeted

### DIFF
--- a/pkg/component/compose.go
+++ b/pkg/component/compose.go
@@ -8,7 +8,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-type ComposeFile struct {
+type ComposeProject struct {
 	root map[string]any
 }
 
@@ -20,15 +20,15 @@ type ComposeDefinitions struct {
 	Configs  map[string]any
 }
 
-func LoadComposeFile(data []byte) (*ComposeFile, error) {
+func ParseComposeProject(data []byte) (*ComposeProject, error) {
 	root := map[string]any{}
 	if len(data) == 0 {
-		return &ComposeFile{root: root}, nil
+		return &ComposeProject{root: root}, nil
 	}
 	if err := yaml.Unmarshal(data, &root); err != nil {
 		return nil, fmt.Errorf("unmarshal compose yaml: %w", err)
 	}
-	return &ComposeFile{root: root}, nil
+	return &ComposeProject{root: root}, nil
 }
 
 func ParseComposeDefinitions(data []byte) (*ComposeDefinitions, error) {
@@ -45,7 +45,7 @@ func ParseComposeDefinitions(data []byte) (*ComposeDefinitions, error) {
 	}, nil
 }
 
-func (c *ComposeFile) Bytes() ([]byte, error) {
+func (c *ComposeProject) Bytes() ([]byte, error) {
 	data, err := yaml.Marshal(c.root)
 	if err != nil {
 		return nil, fmt.Errorf("marshal compose yaml: %w", err)
@@ -53,7 +53,7 @@ func (c *ComposeFile) Bytes() ([]byte, error) {
 	return data, nil
 }
 
-func (c *ComposeFile) RemoveService(name string) bool {
+func (c *ComposeProject) RemoveService(name string) bool {
 	services := c.services()
 	if services == nil {
 		return false
@@ -67,7 +67,7 @@ func (c *ComposeFile) RemoveService(name string) bool {
 	return true
 }
 
-func (c *ComposeFile) AddDefinitions(defs *ComposeDefinitions) {
+func (c *ComposeProject) AddDefinitions(defs *ComposeDefinitions) {
 	if defs == nil {
 		return
 	}
@@ -78,7 +78,7 @@ func (c *ComposeFile) AddDefinitions(defs *ComposeDefinitions) {
 	mergeIntoSection(c.root, "configs", defs.Configs)
 }
 
-func (c *ComposeFile) PruneUnusedResources() {
+func (c *ComposeProject) PruneUnusedResources() {
 	for _, section := range []string{"volumes", "networks", "secrets", "configs"} {
 		entries := nestedMap(c.root[section])
 		if len(entries) == 0 {
@@ -99,7 +99,7 @@ func (c *ComposeFile) PruneUnusedResources() {
 	}
 }
 
-func (c *ComposeFile) services() map[string]any {
+func (c *ComposeProject) services() map[string]any {
 	services := nestedMap(c.root["services"])
 	if services == nil {
 		return nil
@@ -108,7 +108,7 @@ func (c *ComposeFile) services() map[string]any {
 	return services
 }
 
-func (c *ComposeFile) removeServiceDependencyReferences(name string) {
+func (c *ComposeProject) removeServiceDependencyReferences(name string) {
 	for _, rawService := range c.services() {
 		service, ok := rawService.(map[string]any)
 		if !ok {
@@ -137,7 +137,7 @@ func (c *ComposeFile) removeServiceDependencyReferences(name string) {
 	}
 }
 
-func (c *ComposeFile) usedResources(section string) map[string]bool {
+func (c *ComposeProject) usedResources(section string) map[string]bool {
 	used := map[string]bool{}
 	for _, rawService := range c.services() {
 		service, ok := rawService.(map[string]any)

--- a/pkg/component/compose_file.go
+++ b/pkg/component/compose_file.go
@@ -1,0 +1,178 @@
+package component
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type ComposeFile struct {
+	path  string
+	lines []string
+}
+
+func LoadComposeFile(path string) (*ComposeFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read compose file: %w", err)
+	}
+	return &ComposeFile{
+		path:  path,
+		lines: strings.Split(string(data), "\n"),
+	}, nil
+}
+
+func (c *ComposeFile) Save() error {
+	return os.WriteFile(c.path, []byte(strings.Join(c.lines, "\n")), 0o644)
+}
+
+func (c *ComposeFile) DeleteService(name string) error {
+	return c.deleteSectionEntry("services", name)
+}
+
+func (c *ComposeFile) DeleteVolume(name string) error {
+	return c.deleteSectionEntry("volumes", name)
+}
+
+func (c *ComposeFile) DeleteSectionEntry(section, key string) error {
+	return c.deleteSectionEntry(section, key)
+}
+
+func (c *ComposeFile) DeleteServiceEnv(service, key string) error {
+	serviceIdx, ok := c.findService(service)
+	if !ok {
+		return nil
+	}
+	envIdx, envStyle, ok := findEnvironmentBlock(c.lines, serviceIdx)
+	if !ok || envStyle == envInlineEmpty {
+		return nil
+	}
+	keyIdx, ok := findMapKey(c.lines, envIdx+1, key, 6)
+	if !ok {
+		return nil
+	}
+	end := findBlockEnd(c.lines, keyIdx, 6)
+	c.lines = append(c.lines[:keyIdx], c.lines[end:]...)
+	return nil
+}
+
+func (c *ComposeFile) SetServiceEnv(service, key, value string) error {
+	serviceIdx, ok := c.findService(service)
+	if !ok {
+		return fmt.Errorf("service %q not found in compose file", service)
+	}
+	envIdx, envStyle, ok := findEnvironmentBlock(c.lines, serviceIdx)
+	if !ok {
+		insertAt := findBlockEnd(c.lines, serviceIdx, 2)
+		block := []string{
+			"    environment:",
+			fmt.Sprintf("      %s: %q", key, value),
+		}
+		c.lines = insertLines(c.lines, insertAt, block)
+		return nil
+	}
+
+	switch envStyle {
+	case envInlineEmpty:
+		c.lines[envIdx] = "    environment:"
+		c.lines = insertLines(c.lines, envIdx+1, []string{fmt.Sprintf("      %s: %q", key, value)})
+		return nil
+	case envBlock:
+		if keyIdx, ok := findMapKey(c.lines, envIdx+1, key, 6); ok {
+			c.lines[keyIdx] = fmt.Sprintf("      %s: %q", key, value)
+			return nil
+		}
+		insertAt := findBlockEnd(c.lines, envIdx, 4)
+		c.lines = insertLines(c.lines, insertAt, []string{fmt.Sprintf("      %s: %q", key, value)})
+		return nil
+	default:
+		return fmt.Errorf("unsupported environment style for service %q", service)
+	}
+}
+
+func (c *ComposeFile) deleteSectionEntry(section, key string) error {
+	sectionIdx, ok := findMapKey(c.lines, 0, section, 0)
+	if !ok {
+		return nil
+	}
+	entryIdx, ok := findMapKey(c.lines, sectionIdx+1, key, 2)
+	if !ok {
+		return nil
+	}
+	end := findBlockEnd(c.lines, entryIdx, 2)
+	c.lines = append(c.lines[:entryIdx], c.lines[end:]...)
+	return nil
+}
+
+func (c *ComposeFile) findService(service string) (int, bool) {
+	servicesIdx, ok := findMapKey(c.lines, 0, "services", 0)
+	if !ok {
+		return 0, false
+	}
+	return findMapKey(c.lines, servicesIdx+1, service, 2)
+}
+
+type envBlockStyle int
+
+const (
+	envBlock envBlockStyle = iota
+	envInlineEmpty
+)
+
+func findEnvironmentBlock(lines []string, serviceIdx int) (int, envBlockStyle, bool) {
+	serviceEnd := findBlockEnd(lines, serviceIdx, 2)
+	for i := serviceIdx + 1; i < serviceEnd; i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "environment:" {
+			return i, envBlock, true
+		}
+		if trimmed == "environment: {}" {
+			return i, envInlineEmpty, true
+		}
+	}
+	return 0, envBlock, false
+}
+
+func findMapKey(lines []string, start int, key string, indent int) (int, bool) {
+	prefix := strings.Repeat(" ", indent) + key + ":"
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		currentIndent := leadingSpaces(line)
+		if currentIndent < indent {
+			break
+		}
+		if currentIndent == indent && strings.HasPrefix(line, prefix) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func findBlockEnd(lines []string, start int, indent int) int {
+	for i := start + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if leadingSpaces(line) <= indent {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+func insertLines(lines []string, index int, inserted []string) []string {
+	result := make([]string, 0, len(lines)+len(inserted))
+	result = append(result, lines[:index]...)
+	result = append(result, inserted...)
+	result = append(result, lines[index:]...)
+	return result
+}
+
+func leadingSpaces(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}

--- a/pkg/component/compose_file_test.go
+++ b/pkg/component/compose_file_test.go
@@ -1,0 +1,126 @@
+package component
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestComposeFilePreservesAnchorsAndFoldedScalars(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	input := `---
+# Common to all services
+x-common: &common
+  restart: unless-stopped
+  tty: true # keep tty comment
+services:
+  alpaca:
+    <<: *common
+    environment:
+      ALPACA_FCREPO_INDEXER_ENABLED: "true"
+  fcrepo:
+    <<: *common
+    image: islandora/fcrepo6
+  traefik:
+    <<: *common
+    command: >-
+      --ping=true
+      --log.level=INFO
+      --entryPoints.http.address=:80
+volumes:
+  fcrepo-data: {}
+`
+	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	compose, err := LoadComposeFile(path)
+	if err != nil {
+		t.Fatalf("LoadComposeFile() error = %v", err)
+	}
+	if err := compose.DeleteService("fcrepo"); err != nil {
+		t.Fatalf("DeleteService() error = %v", err)
+	}
+	if err := compose.DeleteVolume("fcrepo-data"); err != nil {
+		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+	if err := compose.SetServiceEnv("alpaca", "ALPACA_FCREPO_INDEXER_ENABLED", "false"); err != nil {
+		t.Fatalf("SetServiceEnv() error = %v", err)
+	}
+	if err := compose.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	rendered := string(out)
+	if !strings.Contains(rendered, "x-common: &common") {
+		t.Fatalf("expected anchor preserved, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "<<: *common") {
+		t.Fatalf("expected merge key preserved, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "# keep tty comment") {
+		t.Fatalf("expected comment preserved, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "command: >-") {
+		t.Fatalf("expected folded scalar style preserved, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "      --ping=true\n      --log.level=INFO\n      --entryPoints.http.address=:80") {
+		t.Fatalf("expected folded scalar content preserved, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "\n  fcrepo:\n") {
+		t.Fatalf("expected fcrepo service removed, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "fcrepo-data") {
+		t.Fatalf("expected fcrepo-data removed, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `ALPACA_FCREPO_INDEXER_ENABLED: "false"`) {
+		t.Fatalf("expected updated env value, got:\n%s", rendered)
+	}
+}
+
+func TestComposeFileDeleteServiceEnv(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "docker-compose.yml")
+	input := `services:
+  drupal:
+    environment:
+      DRUPAL_DEFAULT_FCREPO_HOST: fcrepo
+      DRUPAL_DEFAULT_TRIPLESTORE_NAMESPACE: islandora
+`
+	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	compose, err := LoadComposeFile(path)
+	if err != nil {
+		t.Fatalf("LoadComposeFile() error = %v", err)
+	}
+	if err := compose.DeleteServiceEnv("drupal", "DRUPAL_DEFAULT_FCREPO_HOST"); err != nil {
+		t.Fatalf("DeleteServiceEnv() error = %v", err)
+	}
+	if err := compose.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	rendered := string(out)
+	if strings.Contains(rendered, "DRUPAL_DEFAULT_FCREPO_HOST") {
+		t.Fatalf("expected env removed, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "DRUPAL_DEFAULT_TRIPLESTORE_NAMESPACE: islandora") {
+		t.Fatalf("expected unrelated env preserved, got:\n%s", rendered)
+	}
+}

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -244,7 +244,7 @@ func (m *Manager) applyComposeDisable(spec ComposeSpec) error {
 		return fmt.Errorf("read compose file %q: %w", composePath, err)
 	}
 
-	composeFile, err := LoadComposeFile(data)
+	composeFile, err := ParseComposeProject(data)
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func (m *Manager) applyComposeEnable(spec ComposeSpec) error {
 		return fmt.Errorf("read compose file %q: %w", composePath, err)
 	}
 
-	composeFile, err := LoadComposeFile(data)
+	composeFile, err := ParseComposeProject(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -30,9 +30,9 @@ volumes:
   fedora-data: {}
 `)
 
-	composeFile, err := LoadComposeFile(input)
+	composeFile, err := ParseComposeProject(input)
 	if err != nil {
-		t.Fatalf("LoadComposeFile() error = %v", err)
+		t.Fatalf("ParseComposeProject() error = %v", err)
 	}
 
 	if !composeFile.RemoveService("fedora") {

--- a/pkg/component/status.go
+++ b/pkg/component/status.go
@@ -17,9 +17,9 @@ type DetectedState string
 const StateDrifted DetectedState = "drifted"
 
 type DetectOptions struct {
-	ComposeRoot string
+	ComposeRoot  string
 	DrupalRootfs string
-	DrupalRoot  string
+	DrupalRoot   string
 }
 
 type RuleCheckResult struct {

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -37,7 +37,7 @@ type DrupalModuleDependencyMode string
 const (
 	// DrupalModuleDependencyStrict means the module is part of the component's
 	// core contract and should stay aligned with the component state.
-	DrupalModuleDependencyStrict     DrupalModuleDependencyMode = "strict"
+	DrupalModuleDependencyStrict DrupalModuleDependencyMode = "strict"
 	// DrupalModuleDependencyEnableOnly means the module must exist when the
 	// component is enabled, but disabling the component does not imply removing
 	// or uninstalling the module.

--- a/pkg/component/yaml_mutator.go
+++ b/pkg/component/yaml_mutator.go
@@ -33,8 +33,9 @@ func LoadYAMLDocument(data []byte) (*YAMLDocument, error) {
 		return doc, nil
 	}
 
-	if err := yaml.Unmarshal(data, &doc.node); err != nil {
-		return nil, fmt.Errorf("unmarshal yaml document: %w", err)
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&doc.node); err != nil {
+		return nil, fmt.Errorf("decode yaml document: %w", err)
 	}
 	if doc.node.Kind != yaml.DocumentNode {
 		original := doc.node

--- a/pkg/config/local_context.go
+++ b/pkg/config/local_context.go
@@ -10,16 +10,16 @@ import (
 type InputFunc func(question ...string) (string, error)
 
 type LocalContextCreateOptions struct {
-	Name             string
-	DefaultName      string
-	ProjectDir       string
-	DefaultProjectDir string
-	ProjectName      string
+	Name               string
+	DefaultName        string
+	ProjectDir         string
+	DefaultProjectDir  string
+	ProjectName        string
 	DefaultProjectName string
-	DockerSocket     string
-	SetDefault       bool
-	ConfirmOverwrite bool
-	Input            InputFunc
+	DockerSocket       string
+	SetDefault         bool
+	ConfirmOverwrite   bool
+	Input              InputFunc
 }
 
 func PromptAndSaveLocalContext(opts LocalContextCreateOptions) (*Context, error) {

--- a/pkg/config/local_context_test.go
+++ b/pkg/config/local_context_test.go
@@ -194,7 +194,7 @@ func TestPromptAndSaveLocalContextUsesNextAvailableDefaultName(t *testing.T) {
 	}
 
 	ctx, err := PromptAndSaveLocalContext(LocalContextCreateOptions{
-		DefaultName:      "isle-local",
+		DefaultName:       "isle-local",
 		DefaultProjectDir: projectDir,
 		Input: func(question ...string) (string, error) {
 			return "", nil


### PR DESCRIPTION
Leaving it up to plugins to perform compose operations is better done centrally here. And avoid go's YAML marshal/unmarshal from rewriting docker-compose.yaml for untouched surfaces, so make those operations more targeted to exactly what needs changed