### PR TITLE
Add better local context detection for creation prompts

### DIFF
--- a/pkg/config/local_context.go
+++ b/pkg/config/local_context.go
@@ -93,7 +93,20 @@ func resolveLocalContextName(existing Context, opts LocalContextCreateOptions, i
 		return strings.TrimSpace(opts.Name), nil
 	}
 
-	defaultName, err := nextAvailableContextName(firstNonEmpty(existing.Name, opts.DefaultName))
+	baseName := firstNonEmpty(existing.Name, opts.DefaultName)
+	if strings.TrimSpace(baseName) == "" {
+		return "", fmt.Errorf("context name cannot be empty")
+	}
+
+	exists, err := ContextExists(baseName)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return baseName, nil
+	}
+
+	defaultName, err := nextAvailableContextName(baseName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/local_context_test.go
+++ b/pkg/config/local_context_test.go
@@ -67,9 +67,9 @@ func TestPromptAndSaveLocalContextPromptsForMissingValues(t *testing.T) {
 		_ = os.Chdir(oldWd)
 	})
 
-	prompts := []string{"site-a", filepath.Join(tempHome, "site-a")}
+	prompts := []string{filepath.Join(tempHome, "site-a")}
 	ctx, err := PromptAndSaveLocalContext(LocalContextCreateOptions{
-		DefaultName: "default-site",
+		DefaultName: "site-a",
 		Input: func(question ...string) (string, error) {
 			value := prompts[0]
 			prompts = prompts[1:]
@@ -81,7 +81,7 @@ func TestPromptAndSaveLocalContextPromptsForMissingValues(t *testing.T) {
 	}
 
 	if ctx.Name != "site-a" {
-		t.Fatalf("expected prompted name site-a, got %q", ctx.Name)
+		t.Fatalf("expected defaulted name site-a, got %q", ctx.Name)
 	}
 	if ctx.ProjectDir != filepath.Join(tempHome, "site-a") {
 		t.Fatalf("expected prompted project dir, got %q", ctx.ProjectDir)
@@ -125,7 +125,7 @@ func TestPromptAndSaveLocalContextExpandsTildeInPromptedProjectDir(t *testing.T)
 		_ = os.Chdir(oldWd)
 	})
 
-	prompts := []string{"site-home", "~/sites/site-home"}
+	prompts := []string{"~/sites/site-home"}
 	ctx, err := PromptAndSaveLocalContext(LocalContextCreateOptions{
 		DefaultName: "default-site",
 		Input: func(question ...string) (string, error) {
@@ -205,5 +205,41 @@ func TestPromptAndSaveLocalContextUsesNextAvailableDefaultName(t *testing.T) {
 	}
 	if ctx.Name != "isle-local-2" {
 		t.Fatalf("expected auto-suffixed context name, got %q", ctx.Name)
+	}
+}
+
+func TestPromptAndSaveLocalContextPromptsForNameWhenDefaultTaken(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	projectDir := filepath.Join(tempHome, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectDir) error = %v", err)
+	}
+
+	if err := SaveContext(&Context{
+		Name:           "isle-local",
+		DockerHostType: ContextLocal,
+		DockerSocket:   "/var/run/docker.sock",
+		ProjectDir:     projectDir,
+	}, false); err != nil {
+		t.Fatalf("SaveContext(existing) error = %v", err)
+	}
+
+	prompts := []string{"isle-local-custom", projectDir}
+	ctx, err := PromptAndSaveLocalContext(LocalContextCreateOptions{
+		DefaultName: "isle-local",
+		Input: func(question ...string) (string, error) {
+			value := prompts[0]
+			prompts = prompts[1:]
+			return value, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("PromptAndSaveLocalContext() error = %v", err)
+	}
+
+	if ctx.Name != "isle-local-custom" {
+		t.Fatalf("expected prompted name isle-local-custom, got %q", ctx.Name)
 	}
 }


### PR DESCRIPTION
For new installs, people don't need to be asked what context they'd like. Asking will probably just be confusing