### PR TITLE
Clean git history for cloned template repo's

### DIFF
--- a/pkg/plugin/template_repo.go
+++ b/pkg/plugin/template_repo.go
@@ -21,6 +21,8 @@ type GitTemplateOptions struct {
 type gitRunner func(stdout, stderr io.Writer, name string, args ...string) error
 
 var runGitCommand gitRunner = defaultRunGitCommand
+var hasGitRepositoryFunc = hasGitRepository
+var gitRemoteExistsFunc = gitRemoteExists
 
 func (s *SDK) CloneTemplateRepo(opts GitTemplateOptions) error {
 	return CloneTemplateRepo(opts)
@@ -61,10 +63,15 @@ func CloneTemplateRepo(opts GitTemplateOptions) error {
 		return fmt.Errorf("clone template repo %q: %w", opts.TemplateRepo, err)
 	}
 
+	if err := os.RemoveAll(filepath.Join(opts.ProjectDir, ".git")); err != nil {
+		return fmt.Errorf("remove template git history: %w", err)
+	}
+	if err := initializeTemplateRepo(opts, stdout, stderr); err != nil {
+		return err
+	}
 	if opts.GitRemoteURL == "" {
 		return nil
 	}
-
 	return ConfigureTemplateRemotes(opts)
 }
 
@@ -90,13 +97,40 @@ func ConfigureTemplateRemotes(opts GitTemplateOptions) error {
 		stdout = io.Discard
 		stderr = io.Discard
 	}
-	if err := runGitCommand(stdout, stderr, "git", "-C", opts.ProjectDir, "remote", "rename", "origin", opts.TemplateRemoteName); err != nil {
-		return fmt.Errorf("rename template remote to %q: %w", opts.TemplateRemoteName, err)
+	hasGitDir, err := hasGitRepositoryFunc(opts.ProjectDir)
+	if err != nil {
+		return err
+	}
+	if !hasGitDir {
+		if err := initializeTemplateRepo(opts, stdout, stderr); err != nil {
+			return err
+		}
+	}
+
+	hasOrigin, err := gitRemoteExistsFunc(opts.ProjectDir, "origin")
+	if err != nil {
+		return err
+	}
+	if hasOrigin && opts.TemplateRemoteName != "" && opts.TemplateRemoteName != "origin" {
+		if err := runGitCommand(stdout, stderr, "git", "-C", opts.ProjectDir, "remote", "rename", "origin", opts.TemplateRemoteName); err != nil {
+			return fmt.Errorf("rename template remote to %q: %w", opts.TemplateRemoteName, err)
+		}
 	}
 	if err := runGitCommand(stdout, stderr, "git", "-C", opts.ProjectDir, "remote", "add", opts.GitRemoteName, opts.GitRemoteURL); err != nil {
 		return fmt.Errorf("add git remote %q: %w", opts.GitRemoteName, err)
 	}
 
+	return nil
+}
+
+func initializeTemplateRepo(opts GitTemplateOptions, stdout, stderr io.Writer) error {
+	args := []string{"-C", opts.ProjectDir, "init"}
+	if opts.TemplateBranch != "" {
+		args = append(args, "-b", opts.TemplateBranch)
+	}
+	if err := runGitCommand(stdout, stderr, "git", args...); err != nil {
+		return fmt.Errorf("initialize fresh git repository in %q: %w", opts.ProjectDir, err)
+	}
 	return nil
 }
 
@@ -119,4 +153,26 @@ func workingDirFromArgs(args []string) string {
 		}
 	}
 	return ""
+}
+
+func hasGitRepository(projectDir string) (bool, error) {
+	info, err := os.Stat(filepath.Join(projectDir, ".git"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat git directory in %q: %w", projectDir, err)
+	}
+	return info.IsDir(), nil
+}
+
+func gitRemoteExists(projectDir, remoteName string) (bool, error) {
+	cmd := exec.Command("git", "-C", projectDir, "remote", "get-url", remoteName)
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
+			return false, nil
+		}
+		return false, fmt.Errorf("check git remote %q in %q: %w", remoteName, projectDir, err)
+	}
+	return true, nil
 }

--- a/pkg/plugin/template_repo_test.go
+++ b/pkg/plugin/template_repo_test.go
@@ -8,9 +8,15 @@ import (
 
 func TestCloneTemplateRepoWithoutUserRemote(t *testing.T) {
 	oldRunner := runGitCommand
+	oldHasRepo := hasGitRepositoryFunc
+	oldHasRemote := gitRemoteExistsFunc
 	t.Cleanup(func() {
 		runGitCommand = oldRunner
+		hasGitRepositoryFunc = oldHasRepo
+		gitRemoteExistsFunc = oldHasRemote
 	})
+	hasGitRepositoryFunc = func(projectDir string) (bool, error) { return false, nil }
+	gitRemoteExistsFunc = func(projectDir, remoteName string) (bool, error) { return false, nil }
 
 	var calls [][]string
 	runGitCommand = func(stdout, stderr io.Writer, name string, args ...string) error {
@@ -29,6 +35,7 @@ func TestCloneTemplateRepoWithoutUserRemote(t *testing.T) {
 
 	expected := [][]string{
 		{"git", "clone", "--branch", "main", "https://github.com/islandora-devops/isle-site-template", "/tmp/site"},
+		{"git", "-C", "/tmp/site", "init", "-b", "main"},
 	}
 	if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("unexpected git calls: %#v", calls)
@@ -37,9 +44,15 @@ func TestCloneTemplateRepoWithoutUserRemote(t *testing.T) {
 
 func TestCloneTemplateRepoConfiguresUserRemote(t *testing.T) {
 	oldRunner := runGitCommand
+	oldHasRepo := hasGitRepositoryFunc
+	oldHasRemote := gitRemoteExistsFunc
 	t.Cleanup(func() {
 		runGitCommand = oldRunner
+		hasGitRepositoryFunc = oldHasRepo
+		gitRemoteExistsFunc = oldHasRemote
 	})
+	hasGitRepositoryFunc = func(projectDir string) (bool, error) { return true, nil }
+	gitRemoteExistsFunc = func(projectDir, remoteName string) (bool, error) { return false, nil }
 
 	var calls [][]string
 	runGitCommand = func(stdout, stderr io.Writer, name string, args ...string) error {
@@ -61,7 +74,7 @@ func TestCloneTemplateRepoConfiguresUserRemote(t *testing.T) {
 
 	expected := [][]string{
 		{"git", "clone", "--branch", "main", "https://github.com/islandora-devops/isle-site-template", "/tmp/site"},
-		{"git", "-C", "/tmp/site", "remote", "rename", "origin", "upstream"},
+		{"git", "-C", "/tmp/site", "init", "-b", "main"},
 		{"git", "-C", "/tmp/site", "remote", "add", "origin", "git@github.com:example/site.git"},
 	}
 	if !reflect.DeepEqual(calls, expected) {
@@ -84,9 +97,15 @@ func TestCloneTemplateRepoRejectsMatchingRemoteNames(t *testing.T) {
 
 func TestConfigureTemplateRemotes(t *testing.T) {
 	oldRunner := runGitCommand
+	oldHasRepo := hasGitRepositoryFunc
+	oldHasRemote := gitRemoteExistsFunc
 	t.Cleanup(func() {
 		runGitCommand = oldRunner
+		hasGitRepositoryFunc = oldHasRepo
+		gitRemoteExistsFunc = oldHasRemote
 	})
+	hasGitRepositoryFunc = func(projectDir string) (bool, error) { return false, nil }
+	gitRemoteExistsFunc = func(projectDir, remoteName string) (bool, error) { return false, nil }
 
 	var calls [][]string
 	runGitCommand = func(stdout, stderr io.Writer, name string, args ...string) error {
@@ -105,7 +124,7 @@ func TestConfigureTemplateRemotes(t *testing.T) {
 	}
 
 	expected := [][]string{
-		{"git", "-C", "/tmp/site", "remote", "rename", "origin", "upstream"},
+		{"git", "-C", "/tmp/site", "init"},
 		{"git", "-C", "/tmp/site", "remote", "add", "origin", "git@github.com:example/site.git"},
 	}
 	if !reflect.DeepEqual(calls, expected) {


### PR DESCRIPTION
In order to more closely mimic clicking GitHub's "Use this template repo" button on template repositories, remove the git history