### PR TITLE
[minor] add follow up to components

### DIFF
--- a/pkg/component/create.go
+++ b/pkg/component/create.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ type CreateOption struct {
 	Guidance       StateGuidance
 	Shorthand      string
 	PromptOnCreate bool
+	FollowUps      []FollowUpSpec
 }
 
 func (o CreateOption) normalizedDefault() State {
@@ -29,52 +31,115 @@ func (o CreateOption) shouldPromptOnCreate() bool {
 }
 
 func AddCreateFlags(cmd *cobra.Command, options ...CreateOption) {
+	seenFollowUpFlags := map[string]bool{}
 	for _, option := range options {
 		defaultState := option.normalizedDefault()
 		usage := fmt.Sprintf("%s state: %s or %s", option.Name, StateOn, StateOff)
 		if option.Shorthand != "" {
 			cmd.Flags().StringP(option.Name, option.Shorthand, string(defaultState), usage)
-			continue
+		} else {
+			cmd.Flags().String(option.Name, string(defaultState), usage)
 		}
-		cmd.Flags().String(option.Name, string(defaultState), usage)
+		for _, followUp := range option.FollowUps {
+			if !followUp.PromptOnCreate {
+				continue
+			}
+			flagName := followUpFlagName(option.Name, followUp)
+			if flagName == "" || seenFollowUpFlags[flagName] || cmd.Flags().Lookup(flagName) != nil {
+				continue
+			}
+			seenFollowUpFlags[flagName] = true
+			cmd.Flags().String(flagName, strings.TrimSpace(followUp.DefaultValue), createFollowUpUsage(option.Name, followUp))
+		}
 	}
 }
 
 func ResolveCreateStates(cmd *cobra.Command, input InputFunc, options ...CreateOption) (map[string]State, error) {
+	decisions, err := ResolveCreateDecisions(cmd, input, options...)
+	if err != nil {
+		return nil, err
+	}
 	states := make(map[string]State, len(options))
+	for name, decision := range decisions {
+		states[name] = decision.State
+	}
+	return states, nil
+}
+
+func ResolveCreateDecisions(cmd *cobra.Command, input InputFunc, options ...CreateOption) (map[string]ReviewDecision, error) {
+	decisions := make(map[string]ReviewDecision, len(options))
 	for _, option := range options {
 		if option.Name == "" {
 			return nil, fmt.Errorf("component create option name cannot be empty")
 		}
 
+		var state State
 		if cmd.Flags().Changed(option.Name) {
 			value, err := cmd.Flags().GetString(option.Name)
 			if err != nil {
 				return nil, fmt.Errorf("get %s flag: %w", option.Name, err)
 			}
-			state, err := ParseState(value)
+			state, err = ParseState(value)
 			if err != nil {
 				return nil, fmt.Errorf("invalid %s value %q: %w", option.Name, value, err)
 			}
-			states[option.Name] = state
-			continue
+		} else if !option.shouldPromptOnCreate() {
+			state = option.normalizedDefault()
+		} else {
+			guidance := option.Guidance
+			if guidance.DefaultState == "" {
+				guidance.DefaultState = option.normalizedDefault()
+			}
+			var err error
+			state, err = PromptState(option.Name, guidance, input)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		if !option.shouldPromptOnCreate() {
-			states[option.Name] = option.normalizedDefault()
-			continue
+		decision := ReviewDecision{
+			State:   state,
+			Options: map[string]string{},
 		}
-
-		guidance := option.Guidance
-		if guidance.DefaultState == "" {
-			guidance.DefaultState = option.normalizedDefault()
-		}
-		state, err := PromptState(option.Name, guidance, input)
-		if err != nil {
+		if err := PromptCreateFollowUps(cmd, option, &decision, input); err != nil {
 			return nil, err
 		}
-		states[option.Name] = state
+		decisions[option.Name] = decision
 	}
 
-	return states, nil
+	return decisions, nil
+}
+
+func PromptCreateFollowUps(cmd *cobra.Command, option CreateOption, decision *ReviewDecision, input InputFunc) error {
+	if decision == nil {
+		return fmt.Errorf("create decision cannot be nil")
+	}
+	if decision.Options == nil {
+		decision.Options = map[string]string{}
+	}
+
+	for _, followUp := range followUpsForState(option.FollowUps, decision.State) {
+		flagName := followUpFlagName(option.Name, followUp)
+		if flagName != "" && cmd != nil && cmd.Flags().Lookup(flagName) != nil && cmd.Flags().Changed(flagName) {
+			value, err := cmd.Flags().GetString(flagName)
+			if err != nil {
+				return fmt.Errorf("get %s flag: %w", flagName, err)
+			}
+			decision.Options[followUp.Name] = strings.TrimSpace(value)
+			continue
+		}
+		if !followUp.PromptOnCreate {
+			if defaultValue := strings.TrimSpace(followUp.DefaultValue); defaultValue != "" {
+				decision.Options[followUp.Name] = defaultValue
+			}
+			continue
+		}
+
+		value, err := PromptFollowUp(option.Name, followUp, strings.TrimSpace(followUp.DefaultValue), input, nil)
+		if err != nil {
+			return err
+		}
+		decision.Options[followUp.Name] = strings.TrimSpace(value)
+	}
+	return nil
 }

--- a/pkg/component/create_test.go
+++ b/pkg/component/create_test.go
@@ -107,3 +107,63 @@ func TestResolveCreateStatesRejectsInvalidFlagValue(t *testing.T) {
 		t.Fatal("expected invalid flag error")
 	}
 }
+
+func TestResolveCreateDecisionsPromptsForFollowUps(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "create"}
+	AddCreateFlags(cmd,
+		CreateOption{
+			Name:           "fcrepo",
+			Default:        StateOn,
+			PromptOnCreate: true,
+			FollowUps: []FollowUpSpec{
+				{
+					Name:           "isle-file-system-uri",
+					FlagName:       "isle-file-system-uri",
+					PromptOnCreate: true,
+					AppliesTo:      StateOff,
+					Choices: []Choice{
+						{Value: "public", Label: "public", Aliases: []string{"1"}},
+						{Value: "private", Label: "private", Aliases: []string{"2"}},
+					},
+					DefaultValue: "private",
+				},
+			},
+		},
+	)
+
+	inputs := []string{"2", "1"}
+	decisions, err := ResolveCreateDecisions(cmd, func(question ...string) (string, error) {
+		value := inputs[0]
+		inputs = inputs[1:]
+		return value, nil
+	}, CreateOption{
+		Name:           "fcrepo",
+		Default:        StateOn,
+		PromptOnCreate: true,
+		FollowUps: []FollowUpSpec{
+			{
+				Name:           "isle-file-system-uri",
+				FlagName:       "isle-file-system-uri",
+				PromptOnCreate: true,
+				AppliesTo:      StateOff,
+				Choices: []Choice{
+					{Value: "public", Label: "public", Aliases: []string{"1"}},
+					{Value: "private", Label: "private", Aliases: []string{"2"}},
+				},
+				DefaultValue: "private",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveCreateDecisions() error = %v", err)
+	}
+
+	if decisions["fcrepo"].State != StateOff {
+		t.Fatalf("expected fcrepo off, got %q", decisions["fcrepo"].State)
+	}
+	if decisions["fcrepo"].Options["isle-file-system-uri"] != "public" {
+		t.Fatalf("expected public filesystem uri, got %q", decisions["fcrepo"].Options["isle-file-system-uri"])
+	}
+}

--- a/pkg/component/drupal_layout_test.go
+++ b/pkg/component/drupal_layout_test.go
@@ -48,6 +48,7 @@ func TestAddDrupalRootfsFlagUsesDefault(t *testing.T) {
 	flag := cmd.Flags().Lookup("drupal-rootfs")
 	if flag == nil {
 		t.Fatal("expected drupal-rootfs flag")
+		return
 	}
 	if flag.DefValue != DefaultDrupalRootfs {
 		t.Fatalf("expected default %q, got %q", DefaultDrupalRootfs, flag.DefValue)

--- a/pkg/component/followup.go
+++ b/pkg/component/followup.go
@@ -1,0 +1,208 @@
+package component
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/libops/sitectl/pkg/config"
+)
+
+type FollowUpValue struct {
+	Value string
+}
+
+func followUpsForState(specs []FollowUpSpec, state State) []FollowUpSpec {
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]FollowUpSpec, 0, len(specs))
+	for _, spec := range specs {
+		if spec.Name == "" {
+			continue
+		}
+		if spec.AppliesTo != "" && normalizeState(spec.AppliesTo) != normalizeState(state) {
+			continue
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+func followUpFlagName(componentName string, spec FollowUpSpec) string {
+	if strings.TrimSpace(spec.FlagName) != "" {
+		return strings.TrimSpace(spec.FlagName)
+	}
+	if componentName == "" || spec.Name == "" {
+		return ""
+	}
+	return componentName + "-" + spec.Name
+}
+
+func createFollowUpUsage(componentName string, spec FollowUpSpec) string {
+	if strings.TrimSpace(spec.FlagUsage) != "" {
+		return strings.TrimSpace(spec.FlagUsage)
+	}
+	label := strings.TrimSpace(spec.Label)
+	if label == "" {
+		label = strings.TrimSpace(spec.Name)
+	}
+	if componentName == "" {
+		return label
+	}
+	return fmt.Sprintf("%s for %s", label, componentName)
+}
+
+func PromptFollowUp(componentName string, spec FollowUpSpec, defaultValue string, input InputFunc, promptChoice PromptChoiceFunc) (string, error) {
+	if input == nil {
+		input = config.GetInput
+	}
+	if promptChoice == nil {
+		promptChoice = PromptChoice
+	}
+	if len(spec.Choices) == 0 {
+		lines := []string{}
+		if section := RenderFollowUpSection(componentName, spec); section != "" {
+			lines = append(lines, strings.Split(section, "\n")...)
+		}
+		prompt := strings.TrimSpace(spec.CustomPrompt)
+		if prompt == "" {
+			label := strings.TrimSpace(spec.Label)
+			if label == "" {
+				label = spec.Name
+			}
+			prompt = label + ": "
+		}
+		lines = append(lines, "", RenderPromptLine(prompt))
+		value, err := input(lines...)
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(value) == "" {
+			return strings.TrimSpace(defaultValue), nil
+		}
+		return strings.TrimSpace(value), nil
+	}
+
+	promptName := followUpFlagName(componentName, spec)
+	if promptName == "" {
+		promptName = spec.Name
+	}
+	value, err := promptChoice(promptName, spec.Choices, defaultValue, input, strings.Split(RenderFollowUpSection(componentName, spec), "\n")...)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(spec.CustomPrompt) != "" && isCustomChoice(spec, value) {
+		lines := []string{}
+		if section := RenderFollowUpSection(componentName, spec); section != "" {
+			lines = append(lines, strings.Split(section, "\n")...)
+		}
+		lines = append(lines, "", RenderPromptLine(spec.CustomPrompt))
+		customValue, err := input(lines...)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(customValue), nil
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func RenderFollowUpSection(componentName string, spec FollowUpSpec) string {
+	title := strings.TrimSpace(spec.Label)
+	if title == "" {
+		title = strings.TrimSpace(spec.Name)
+	}
+	if componentName != "" && title != "" {
+		title = componentName + ": " + title
+	}
+	return RenderSection(title, strings.TrimSpace(spec.Question))
+}
+
+func isCustomChoice(spec FollowUpSpec, value string) bool {
+	for _, choice := range spec.Choices {
+		if choice.Value != value {
+			continue
+		}
+		return choice.AllowCustomInput
+	}
+	return false
+}
+
+func RenderConfiguredFollowUps(view ReviewView) []string {
+	if len(view.Definition.FollowUps) == 0 || len(view.FollowUpValues) == 0 {
+		return nil
+	}
+	lines := []string{}
+	for _, spec := range view.Definition.FollowUps {
+		value := strings.TrimSpace(view.FollowUpValues[spec.Name])
+		if value == "" {
+			continue
+		}
+		if view.State != StateDrifted && spec.AppliesTo != "" && normalizeState(spec.AppliesTo) != normalizeState(State(view.State)) {
+			continue
+		}
+		label := strings.TrimSpace(spec.Label)
+		if label == "" {
+			label = spec.Name
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", label, value))
+	}
+	return lines
+}
+
+func PromptDeclaredReviewFollowUps(view ReviewView, decision *ReviewDecision, input InputFunc, promptChoice PromptChoiceFunc) error {
+	if decision == nil {
+		return fmt.Errorf("review decision cannot be nil")
+	}
+	if decision.Options == nil {
+		decision.Options = map[string]string{}
+	}
+	for _, spec := range view.Definition.FollowUpsForState(decision.State) {
+		defaultValue := strings.TrimSpace(view.FollowUpValues[spec.Name])
+		if defaultValue == "" {
+			defaultValue = strings.TrimSpace(spec.DefaultValue)
+		}
+		value, err := PromptFollowUp(view.Name, spec, defaultValue, input, promptChoice)
+		if err != nil {
+			return err
+		}
+		decision.Options[spec.Name] = strings.TrimSpace(value)
+	}
+	return nil
+}
+
+func RenderDecisionFollowUps(def Definition, decision ReviewDecision) string {
+	parts := []string{}
+	for _, spec := range def.FollowUpsForState(decision.State) {
+		value := strings.TrimSpace(decision.Options[spec.Name])
+		if value == "" {
+			continue
+		}
+		label := strings.TrimSpace(spec.Label)
+		if label == "" {
+			label = spec.Name
+		}
+		parts = append(parts, fmt.Sprintf("%s: `%s`.", label, value))
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildReportFollowUps(view ReviewView) map[string]string {
+	if len(view.FollowUpValues) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for _, spec := range view.Definition.FollowUps {
+		value := strings.TrimSpace(view.FollowUpValues[spec.Name])
+		if value == "" {
+			continue
+		}
+		if view.State != StateDrifted && spec.AppliesTo != "" && normalizeState(spec.AppliesTo) != normalizeState(State(view.State)) {
+			continue
+		}
+		out[spec.Name] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/pkg/component/review.go
+++ b/pkg/component/review.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -13,13 +14,14 @@ import (
 )
 
 type ReviewView struct {
-	Definition  Definition
-	Name        string
-	State       DetectedState
-	Detail      string
-	DriftDetail string
-	SDKStatus   *ComponentStatus
-	Extra       any
+	Definition     Definition
+	Name           string
+	State          DetectedState
+	Detail         string
+	DriftDetail    string
+	SDKStatus      *ComponentStatus
+	FollowUpValues map[string]string
+	Extra          any
 }
 
 type ReviewDecision struct {
@@ -28,16 +30,18 @@ type ReviewDecision struct {
 }
 
 type PromptStateFunc func(name string, guidance StateGuidance, input InputFunc) (State, error)
+type PromptChoiceFunc func(name string, choices []Choice, defaultValue string, input InputFunc, sections ...string) (string, error)
 type SummaryLineFunc func(view ReviewView, decision ReviewDecision) (string, error)
 type ReviewPromptExtraFunc func(view ReviewView, decision *ReviewDecision) error
 type ReviewConfirmFunc func(prompt string) (bool, error)
 
 type ReviewOptions struct {
-	Input       InputFunc
-	PromptState PromptStateFunc
-	PromptExtra ReviewPromptExtraFunc
-	SummaryLine SummaryLineFunc
-	Confirm     ReviewConfirmFunc
+	Input        InputFunc
+	PromptState  PromptStateFunc
+	PromptChoice PromptChoiceFunc
+	PromptExtra  ReviewPromptExtraFunc
+	SummaryLine  SummaryLineFunc
+	Confirm      ReviewConfirmFunc
 }
 
 type ReviewMode struct {
@@ -53,14 +57,15 @@ const (
 )
 
 type ReportRow struct {
-	Name            string   `json:"name" yaml:"name"`
-	State           string   `json:"state" yaml:"state"`
-	DetectedMode    string   `json:"detected_mode,omitempty" yaml:"detected_mode,omitempty"`
-	CurrentGuidance string   `json:"current_guidance,omitempty" yaml:"current_guidance,omitempty"`
-	IfEnabled       string   `json:"if_enabled" yaml:"if_enabled"`
-	IfDisabled      string   `json:"if_disabled" yaml:"if_disabled"`
-	DriftDetail     string   `json:"drift_detail,omitempty" yaml:"drift_detail,omitempty"`
-	DriftChecks     []string `json:"drift_checks,omitempty" yaml:"drift_checks,omitempty"`
+	Name            string            `json:"name" yaml:"name"`
+	State           string            `json:"state" yaml:"state"`
+	DetectedMode    string            `json:"detected_mode,omitempty" yaml:"detected_mode,omitempty"`
+	FollowUps       map[string]string `json:"follow_ups,omitempty" yaml:"follow_ups,omitempty"`
+	CurrentGuidance string            `json:"current_guidance,omitempty" yaml:"current_guidance,omitempty"`
+	IfEnabled       string            `json:"if_enabled" yaml:"if_enabled"`
+	IfDisabled      string            `json:"if_disabled" yaml:"if_disabled"`
+	DriftDetail     string            `json:"drift_detail,omitempty" yaml:"drift_detail,omitempty"`
+	DriftChecks     []string          `json:"drift_checks,omitempty" yaml:"drift_checks,omitempty"`
 }
 
 func AddReviewFlags(cmd *cobra.Command, reportTarget, verboseTarget *bool, formatTarget *string) {
@@ -89,6 +94,10 @@ func RenderComponentStatus(view ReviewView) string {
 	if guidance := RenderCurrentGuidance(view); guidance != "" {
 		lines = append(lines, "", guidance)
 	}
+	if followUps := RenderConfiguredFollowUps(view); len(followUps) > 0 {
+		lines = append(lines, "", "Configured follow-ups:")
+		lines = append(lines, followUps...)
+	}
 	lines = append(lines,
 		"",
 		fmt.Sprintf("If enabled: %s", RenderTransitionSummary(view.Definition.Behavior.Enable)),
@@ -112,6 +121,10 @@ func BuildReviewQuestion(view ReviewView) string {
 	}
 	if strings.TrimSpace(view.Definition.Guidance.Question) != "" {
 		lines = append(lines, "", strings.TrimSpace(view.Definition.Guidance.Question))
+	}
+	if followUps := RenderConfiguredFollowUps(view); len(followUps) > 0 {
+		lines = append(lines, "", "Configured follow-ups:")
+		lines = append(lines, followUps...)
 	}
 	lines = append(lines,
 		"",
@@ -199,6 +212,9 @@ func RunReview(views []ReviewView, opts ReviewOptions) (map[string]ReviewDecisio
 		}
 
 		decision := ReviewDecision{State: state, Options: map[string]string{}}
+		if err := PromptDeclaredReviewFollowUps(view, &decision, input, opts.PromptChoice); err != nil {
+			return nil, err
+		}
 		if opts.PromptExtra != nil {
 			if err := opts.PromptExtra(view, &decision); err != nil {
 				return nil, err
@@ -236,6 +252,9 @@ func RenderReviewSummary(views []ReviewView, decisions map[string]ReviewDecision
 			return "", fmt.Errorf("missing review decision for %q", view.Name)
 		}
 		line := fmt.Sprintf("Set `%s` to `%s`.", view.Name, decision.State)
+		if rendered := RenderDecisionFollowUps(view.Definition, decision); rendered != "" {
+			line = fmt.Sprintf("%s %s", line, rendered)
+		}
 		var err error
 		if summaryLine != nil {
 			line, err = summaryLine(view, decision)
@@ -308,6 +327,7 @@ func BuildComponentStatusRows(views []ReviewView, verbose bool) []ReportRow {
 			Name:            view.Name,
 			State:           string(view.State),
 			DetectedMode:    strings.TrimSpace(view.Detail),
+			FollowUps:       buildReportFollowUps(view),
 			CurrentGuidance: RenderCurrentGuidance(view),
 			IfEnabled:       RenderTransitionSummary(view.Definition.Behavior.Enable),
 			IfDisabled:      RenderTransitionSummary(view.Definition.Behavior.Disable),
@@ -346,7 +366,7 @@ func writeComponentStatusTable(out io.Writer, rows []ReportRow) error {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			row.Name,
 			row.State,
-			fallbackReportValue(row.DetectedMode),
+			fallbackReportValue(renderReportMode(row)),
 			fallbackReportValue(row.CurrentGuidance),
 			fallbackReportValue(row.IfEnabled),
 			fallbackReportValue(row.IfDisabled),
@@ -412,4 +432,26 @@ func fallbackReportValue(value string) string {
 		return "-"
 	}
 	return strings.TrimSpace(value)
+}
+
+func renderReportMode(row ReportRow) string {
+	parts := []string{}
+	if strings.TrimSpace(row.DetectedMode) != "" {
+		parts = append(parts, strings.TrimSpace(row.DetectedMode))
+	}
+	if len(row.FollowUps) > 0 {
+		keys := make([]string, 0, len(row.FollowUps))
+		for key := range row.FollowUps {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			value := strings.TrimSpace(row.FollowUps[key])
+			if value == "" {
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+	return strings.Join(parts, "; ")
 }

--- a/pkg/component/review_test.go
+++ b/pkg/component/review_test.go
@@ -41,9 +41,22 @@ func TestRenderComponentStatusIncludesTransitionBehavior(t *testing.T) {
 func TestRunReviewCapturesExtraOptionsAndSummary(t *testing.T) {
 	views := []ReviewView{
 		{
-			Definition: Definition{Name: "isle-tls"},
-			Name:       "isle-tls",
-			State:      DetectedState(StateOff),
+			Definition: Definition{
+				Name: "isle-tls",
+				FollowUps: []FollowUpSpec{
+					{
+						Name:      "tls-mode",
+						Label:     "TLS mode",
+						AppliesTo: StateOn,
+						Choices: []Choice{
+							{Value: "mkcert", Label: "mkcert", Aliases: []string{"1"}},
+						},
+					},
+				},
+			},
+			Name:           "isle-tls",
+			State:          DetectedState(StateOff),
+			FollowUpValues: map[string]string{"tls-mode": "mkcert"},
 		},
 	}
 
@@ -53,12 +66,8 @@ func TestRunReviewCapturesExtraOptionsAndSummary(t *testing.T) {
 		PromptState: func(name string, guidance StateGuidance, input InputFunc) (State, error) {
 			return StateOn, nil
 		},
-		PromptExtra: func(view ReviewView, decision *ReviewDecision) error {
-			decision.Options["tls-mode"] = "mkcert"
-			return nil
-		},
-		SummaryLine: func(view ReviewView, decision ReviewDecision) (string, error) {
-			return "Set `" + view.Name + "` to `" + string(decision.State) + "`. Requested mode: `" + decision.Options["tls-mode"] + "`.", nil
+		PromptChoice: func(name string, choices []Choice, defaultValue string, input InputFunc, sections ...string) (string, error) {
+			return "mkcert", nil
 		},
 		Confirm: func(prompt string) (bool, error) {
 			confirmedPrompt = prompt
@@ -75,7 +84,7 @@ func TestRunReviewCapturesExtraOptionsAndSummary(t *testing.T) {
 	if decisions["isle-tls"].Options["tls-mode"] != "mkcert" {
 		t.Fatalf("expected tls-mode mkcert, got %q", decisions["isle-tls"].Options["tls-mode"])
 	}
-	if !strings.Contains(confirmedPrompt, "Requested mode: `mkcert`.") {
+	if !strings.Contains(confirmedPrompt, "TLS mode: `mkcert`.") {
 		t.Fatalf("expected summary prompt to include extra option, got:\n%s", confirmedPrompt)
 	}
 }
@@ -145,6 +154,25 @@ func TestWriteComponentStatusReportWithFormatJSON(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "\"name\": \"fcrepo\"") {
 		t.Fatalf("expected json output, got:\n%s", out.String())
+	}
+}
+
+func TestBuildComponentStatusRowsIncludesFollowUps(t *testing.T) {
+	view := ReviewView{
+		Definition: Definition{
+			Name: "fcrepo",
+			FollowUps: []FollowUpSpec{
+				{Name: "isle-file-system-uri", Label: "Drupal filesystem URI", AppliesTo: StateOff},
+			},
+		},
+		Name:           "fcrepo",
+		State:          DetectedState(StateOff),
+		FollowUpValues: map[string]string{"isle-file-system-uri": "public"},
+	}
+
+	rows := BuildComponentStatusRows([]ReviewView{view}, false)
+	if rows[0].FollowUps["isle-file-system-uri"] != "public" {
+		t.Fatalf("expected follow-up in report rows, got %#v", rows[0].FollowUps)
 	}
 }
 

--- a/pkg/component/types.go
+++ b/pkg/component/types.go
@@ -54,6 +54,19 @@ type Dependencies struct {
 	DrupalModules []DrupalModuleDependency
 }
 
+type FollowUpSpec struct {
+	Name           string
+	Label          string
+	FlagName       string
+	FlagUsage      string
+	Question       string
+	Choices        []Choice
+	DefaultValue   string
+	PromptOnCreate bool
+	AppliesTo      State
+	CustomPrompt   string
+}
+
 type DataMigrationRequirement string
 
 const (
@@ -83,6 +96,7 @@ type Definition struct {
 	DefaultState   State
 	Guidance       StateGuidance
 	PromptOnCreate bool
+	FollowUps      []FollowUpSpec
 	Gates          GateSpec
 	Dependencies   Dependencies
 	Behavior       Behavior
@@ -112,7 +126,25 @@ func (d Definition) CreateOption() CreateOption {
 		Default:        d.DefaultState,
 		Guidance:       d.Guidance,
 		PromptOnCreate: d.PromptOnCreate,
+		FollowUps:      d.FollowUps,
 	}
+}
+
+func (d Definition) FollowUpsForState(state State) []FollowUpSpec {
+	if len(d.FollowUps) == 0 {
+		return nil
+	}
+	out := make([]FollowUpSpec, 0, len(d.FollowUps))
+	for _, spec := range d.FollowUps {
+		if spec.Name == "" {
+			continue
+		}
+		if spec.AppliesTo != "" && normalizeState(spec.AppliesTo) != normalizeState(state) {
+			continue
+		}
+		out = append(out, spec)
+	}
+	return out
 }
 
 func ParseStateOverrides(values map[string]string) (map[string]State, error) {

--- a/pkg/component/types_test.go
+++ b/pkg/component/types_test.go
@@ -148,6 +148,9 @@ func TestDefinitionCreateOptionIncludesPromptOnCreate(t *testing.T) {
 		DefaultState:   StateOn,
 		Guidance:       StateGuidance{Question: "fcrepo?"},
 		PromptOnCreate: true,
+		FollowUps: []FollowUpSpec{
+			{Name: "isle-file-system-uri", PromptOnCreate: true, AppliesTo: StateOff},
+		},
 	}
 
 	option := def.CreateOption()
@@ -162,6 +165,9 @@ func TestDefinitionCreateOptionIncludesPromptOnCreate(t *testing.T) {
 	}
 	if option.Guidance.Question != "fcrepo?" {
 		t.Fatalf("expected guidance question preserved, got %q", option.Guidance.Question)
+	}
+	if len(option.FollowUps) != 1 || option.FollowUps[0].Name != "isle-file-system-uri" {
+		t.Fatalf("expected follow-up metadata preserved, got %#v", option.FollowUps)
 	}
 }
 


### PR DESCRIPTION
for components that when changed need additional settings configured. e.g. when turning fcrepo off in the ISLE plugin, selecting with drupal URI will replace `fedora` can now be defined within the fcrepo component. This provides plugins a path for this common need, and also lets those additional configurations to be surfaced in component reviews