### PR TITLE
[minor] feat: let plugins claim cwd contexts

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/libops/sitectl/pkg/config"
-	"github.com/libops/sitectl/pkg/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// since we're disabling flag parsing to make easy passing of flags to docker compose
 		// handle the context flag
-		filteredArgs, sitectlContext, err := helpers.GetContextFromArgs(cmd, args)
+		filteredArgs, sitectlContext, err := getContextFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/context_args.go
+++ b/cmd/context_args.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/libops/sitectl/pkg/config"
+	"github.com/libops/sitectl/pkg/helpers"
+	"github.com/spf13/cobra"
+)
+
+func getContextFromArgs(cmd *cobra.Command, args []string) ([]string, string, error) {
+	filteredArgs, contextName, err := helpers.GetContextFromArgs(cmd, args)
+	if err != nil {
+		return nil, "", err
+	}
+	if contextName != "" {
+		return filteredArgs, contextName, nil
+	}
+	contextName, err = config.ResolveCurrentContextName(cmd.Root().PersistentFlags())
+	if err != nil {
+		return nil, "", err
+	}
+	return filteredArgs, contextName, nil
+}

--- a/cmd/converge.go
+++ b/cmd/converge.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/libops/sitectl/pkg/config"
-	"github.com/libops/sitectl/pkg/helpers"
 	"github.com/libops/sitectl/pkg/plugin"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +27,7 @@ Examples:
   sitectl converge --component fcrepo`,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filteredArgs, contextName, err := helpers.GetContextFromArgs(cmd, args)
+		filteredArgs, contextName, err := getContextFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -10,7 +10,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/libops/sitectl/pkg/config"
-	"github.com/libops/sitectl/pkg/helpers"
 	corejob "github.com/libops/sitectl/pkg/job"
 	"github.com/libops/sitectl/pkg/plugin"
 	"github.com/spf13/cobra"
@@ -66,7 +65,7 @@ var jobExecCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filteredArgs, contextName, err := helpers.GetContextFromArgs(cmd, args)
+		filteredArgs, contextName, err := getContextFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,17 +71,14 @@ func SetVersionInfo(version, commit, date string) {
 }
 
 func init() {
-	c, err := config.Current()
-	if err != nil {
-		slog.Error("Unable to fetch current context", "err", err)
-	}
+	config.SetProjectClaimDetector(plugin.DetectProjectOwner)
 
 	ll := os.Getenv("LOG_LEVEL")
 	if ll == "" {
 		ll = "INFO"
 	}
 
-	RootCmd.PersistentFlags().String("context", c, "The sitectl context to use. See sitectl config --help for more info")
+	RootCmd.PersistentFlags().String("context", "", "The sitectl context to use. See sitectl config --help for more info")
 	RootCmd.PersistentFlags().String("log-level", ll, "The logging level for the command")
 
 	RootCmd.AddGroup(

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/libops/sitectl/pkg/config"
-	"github.com/libops/sitectl/pkg/helpers"
 	"github.com/libops/sitectl/pkg/plugin"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +28,7 @@ Examples:
   sitectl set isle-tls on --tls-mode letsencrypt`,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filteredArgs, contextName, err := helpers.GetContextFromArgs(cmd, args)
+		filteredArgs, contextName, err := getContextFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/libops/sitectl/pkg/config"
-	"github.com/libops/sitectl/pkg/helpers"
 	"github.com/libops/sitectl/pkg/plugin"
 	sitevalidate "github.com/libops/sitectl/pkg/validate"
 	"github.com/spf13/cobra"
@@ -35,7 +34,7 @@ Examples:
   sitectl validate --drupal-rootfs drupal/rootfs`,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filteredArgs, contextName, err := helpers.GetContextFromArgs(cmd, args)
+		filteredArgs, contextName, err := getContextFromArgs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -29,6 +29,8 @@ const (
 	DispositionSuperseded  Disposition = "superceded"
 	DispositionEnabled     Disposition = "enabled"
 	DispositionDistributed Disposition = "distributed"
+	DispositionCantaloupe  Disposition = "cantaloupe"
+	DispositionTriplet     Disposition = "triplet"
 )
 
 type ComposeSpec struct {
@@ -493,10 +495,10 @@ func normalizeState(state State) State {
 func ParseDisposition(value string) (Disposition, error) {
 	disposition := normalizeDisposition(Disposition(value))
 	switch disposition {
-	case DispositionDisabled, DispositionSuperseded, DispositionEnabled, DispositionDistributed:
+	case DispositionDisabled, DispositionSuperseded, DispositionEnabled, DispositionDistributed, DispositionCantaloupe, DispositionTriplet:
 		return disposition, nil
 	default:
-		return "", fmt.Errorf("invalid component disposition %q: expected one of %s, %s, %s, %s", value, DispositionDisabled, DispositionSuperseded, DispositionEnabled, DispositionDistributed)
+		return "", fmt.Errorf("invalid component disposition %q: expected one of %s, %s, %s, %s, %s, %s", value, DispositionDisabled, DispositionSuperseded, DispositionEnabled, DispositionDistributed, DispositionCantaloupe, DispositionTriplet)
 	}
 }
 
@@ -517,6 +519,10 @@ func normalizeDisposition(disposition Disposition) Disposition {
 		return DispositionEnabled
 	case string(DispositionDistributed):
 		return DispositionDistributed
+	case string(DispositionCantaloupe):
+		return DispositionCantaloupe
+	case string(DispositionTriplet):
+		return DispositionTriplet
 	default:
 		return Disposition(strings.ToLower(strings.TrimSpace(string(disposition))))
 	}
@@ -524,7 +530,7 @@ func normalizeDisposition(disposition Disposition) Disposition {
 
 func DispositionToState(disposition Disposition) State {
 	switch normalizeDisposition(disposition) {
-	case DispositionEnabled:
+	case DispositionEnabled, DispositionDistributed, DispositionTriplet:
 		return StateOn
 	default:
 		return StateOff

--- a/pkg/component/prompt.go
+++ b/pkg/component/prompt.go
@@ -268,6 +268,16 @@ func dispositionHelp(guidance StateGuidance, disposition Disposition) string {
 		return guidance.SupersededHelp
 	case DispositionDistributed:
 		return guidance.DistributedHelp
+	case DispositionTriplet:
+		if strings.TrimSpace(guidance.EnabledHelp) != "" {
+			return guidance.EnabledHelp
+		}
+		return guidance.OnHelp
+	case DispositionCantaloupe:
+		if strings.TrimSpace(guidance.DisabledHelp) != "" {
+			return guidance.DisabledHelp
+		}
+		return guidance.OffHelp
 	default:
 		return ""
 	}

--- a/pkg/component/review.go
+++ b/pkg/component/review.go
@@ -178,6 +178,10 @@ func RenderCurrentGuidance(view ReviewView) string {
 		return strings.TrimSpace(dispositionHelp(view.Definition.Guidance, DispositionSuperseded))
 	case DispositionDistributed:
 		return strings.TrimSpace(dispositionHelp(view.Definition.Guidance, DispositionDistributed))
+	case DispositionTriplet:
+		return strings.TrimSpace(dispositionHelp(view.Definition.Guidance, DispositionTriplet))
+	case DispositionCantaloupe:
+		return strings.TrimSpace(dispositionHelp(view.Definition.Guidance, DispositionCantaloupe))
 	}
 	switch view.State {
 	case DetectedState(StateOn):
@@ -302,28 +306,10 @@ func LegacyDispositionForState(allowed []Disposition, state State) Disposition {
 	if len(allowed) == 0 {
 		return StateToDisposition(state)
 	}
-	switch normalizeState(state) {
-	case StateOn:
-		for _, disposition := range allowed {
-			if disposition == DispositionEnabled {
-				return disposition
-			}
-		}
-		for _, disposition := range allowed {
-			if disposition != DispositionDisabled {
-				return disposition
-			}
-		}
-	case StateOff:
-		for _, disposition := range allowed {
-			if disposition == DispositionDisabled {
-				return disposition
-			}
-		}
-		for _, disposition := range allowed {
-			if disposition != DispositionEnabled {
-				return disposition
-			}
+	target := normalizeState(state)
+	for _, disposition := range allowed {
+		if DispositionToState(disposition) == target {
+			return disposition
 		}
 	}
 	return allowed[0]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -57,21 +59,69 @@ func Save(cfg *Config) error {
 }
 
 func Current() (string, error) {
+	return CurrentForPlugin("")
+}
+
+func CurrentForPlugin(pluginName string) (string, error) {
+	return currentForPlugin(pluginName, nil)
+}
+
+func CurrentForPluginWithDiagnostics(pluginName string, diagnostics io.Writer) (string, error) {
+	return currentForPlugin(pluginName, diagnostics)
+}
+
+func currentForPlugin(pluginName string, diagnostics io.Writer) (string, error) {
 	cfg, err := Load()
 	if err != nil {
 		return "", err
 	}
 	current := cfg.CurrentContext
 
-	if discovered, err := DiscoverCurrentContext(); err == nil && discovered != nil {
-		return discovered.Name, nil
-	} else if err != nil {
+	discovery, err := DiscoverCurrentContextForPlugin(pluginName)
+	if err != nil {
 		return "", err
 	}
+	if discovery.Context != nil {
+		printContextDiscovery(diagnostics, fmt.Sprintf("using context %q from compose project %s claimed by plugin %q%s", discovery.Context.Name, discovery.ComposeProjectDir, discovery.Claim.Plugin, discoveryReason(discovery.Claim)))
+		return discovery.Context.Name, nil
+	}
+	printFallbackDiscovery(diagnostics, discovery, current)
 
 	if current == "" {
 		return "", nil
 	}
 
 	return current, nil
+}
+
+func printFallbackDiscovery(w io.Writer, discovery CurrentContextDiscovery, current string) {
+	if w == nil {
+		return
+	}
+	defaultText := "no default context is set"
+	if strings.TrimSpace(current) != "" {
+		defaultText = fmt.Sprintf("using default context %q", current)
+	}
+	switch {
+	case strings.TrimSpace(discovery.ComposeProjectDir) == "":
+		printContextDiscovery(w, fmt.Sprintf("no compose project detected from %s; %s", discovery.CWD, defaultText))
+	case discovery.Claim == nil:
+		printContextDiscovery(w, fmt.Sprintf("no plugin claimed compose project %s; %s", discovery.ComposeProjectDir, defaultText))
+	default:
+		printContextDiscovery(w, fmt.Sprintf("plugin %q claimed compose project %s%s, but no matching local context exists; %s", discovery.Claim.Plugin, discovery.ComposeProjectDir, discoveryReason(discovery.Claim), defaultText))
+	}
+}
+
+func printContextDiscovery(w io.Writer, message string) {
+	if w == nil || strings.TrimSpace(message) == "" {
+		return
+	}
+	fmt.Fprintf(w, "sitectl: %s\n", message)
+}
+
+func discoveryReason(claim *ProjectClaim) string {
+	if claim == nil || strings.TrimSpace(claim.Reason) == "" {
+		return ""
+	}
+	return " (" + strings.TrimSpace(claim.Reason) + ")"
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -83,6 +83,16 @@ func TestCurrentPrefersAutodiscoveredLocalContext(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(projectDir) error = %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yml"), []byte("services:\n  drupal:\n    image: drupal:latest\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(docker-compose.yml) error = %v", err)
+	}
+	previousDetector := projectClaimDetector
+	SetProjectClaimDetector(func(projectDir, requestedPlugin string) (*ProjectClaim, error) {
+		return &ProjectClaim{Plugin: "isle", ProjectDir: projectDir, Reason: "test claim"}, nil
+	})
+	t.Cleanup(func() {
+		SetProjectClaimDetector(previousDetector)
+	})
 
 	oldWd, err := os.Getwd()
 	if err != nil {
@@ -98,8 +108,8 @@ func TestCurrentPrefersAutodiscoveredLocalContext(t *testing.T) {
 	cfg := &Config{
 		CurrentContext: "other",
 		Contexts: []Context{
-			{Name: "other", DockerHostType: ContextLocal, ProjectDir: filepath.Join(tmpDir, "other")},
-			{Name: "site-local", DockerHostType: ContextLocal, ProjectDir: projectDir},
+			{Name: "other", Plugin: "isle", DockerHostType: ContextLocal, ProjectDir: filepath.Join(tmpDir, "other")},
+			{Name: "site-local", Plugin: "isle", DockerHostType: ContextLocal, ProjectDir: projectDir},
 		},
 	}
 	if err := Save(cfg); err != nil {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -173,6 +173,10 @@ func CurrentContext(f *pflag.FlagSet) (*Context, error) {
 }
 
 func ResolveCurrentContextName(f *pflag.FlagSet) (string, error) {
+	return ResolveCurrentContextNameForPlugin(f, "")
+}
+
+func ResolveCurrentContextNameForPlugin(f *pflag.FlagSet, pluginName string) (string, error) {
 	if f != nil && f.Lookup("context") != nil && f.Changed("context") {
 		c, err := f.GetString("context")
 		if err != nil {
@@ -188,7 +192,7 @@ func ResolveCurrentContextName(f *pflag.FlagSet) (string, error) {
 		return c, nil
 	}
 
-	c, err := Current()
+	c, err := CurrentForPluginWithDiagnostics(pluginName, os.Stderr)
 	if err != nil {
 		return "", fmt.Errorf("unable to load sitectl config. Have you ran `sitectl config set-context`?")
 	}

--- a/pkg/config/discovery.go
+++ b/pkg/config/discovery.go
@@ -92,6 +92,42 @@ func DetectComposeNetworkName(projectDir, composeProjectName string) string {
 	return preferredComposeNetworkName(doc, composeProjectName)
 }
 
+func FindComposeProjectRoot(startDir string) string {
+	startDir = filepath.Clean(strings.TrimSpace(startDir))
+	if startDir == "" {
+		return ""
+	}
+	if resolved, err := filepath.Abs(startDir); err == nil {
+		startDir = resolved
+	}
+	for {
+		if LooksLikeComposeProject(startDir) {
+			return startDir
+		}
+		parent := filepath.Dir(startDir)
+		if parent == startDir {
+			return ""
+		}
+		startDir = parent
+	}
+}
+
+func DetectComposeServices(projectDir string) []string {
+	doc, ok := readComposeDiscoveryDoc(projectDir)
+	if !ok {
+		return nil
+	}
+	services := make([]string, 0, len(doc.Services))
+	for service := range doc.Services {
+		service = strings.TrimSpace(service)
+		if service != "" {
+			services = append(services, service)
+		}
+	}
+	sort.Strings(services)
+	return services
+}
+
 func DetectContextComposeNetwork(ctx *Context) string {
 	if ctx == nil {
 		return ""
@@ -267,7 +303,12 @@ func effectiveComposeNetworkName(key string, network composeDiscoveryNetwork, co
 }
 
 func FindLocalContextByProjectDir(projectDir string) (*Context, error) {
+	return FindLocalContextByProjectDirAndPlugin(projectDir, "")
+}
+
+func FindLocalContextByProjectDirAndPlugin(projectDir, pluginName string) (*Context, error) {
 	projectDir = filepath.Clean(strings.TrimSpace(projectDir))
+	pluginName = strings.TrimSpace(pluginName)
 	if projectDir == "" {
 		return nil, nil
 	}
@@ -288,16 +329,76 @@ func FindLocalContextByProjectDir(projectDir string) (*Context, error) {
 			storedDir = resolved
 		}
 		if storedDir == projectDir {
+			if pluginName != "" && !strings.EqualFold(strings.TrimSpace(ctx.Plugin), pluginName) {
+				continue
+			}
 			return ctx, nil
 		}
 	}
 	return nil, nil
 }
 
+type ProjectClaim struct {
+	Plugin     string `yaml:"plugin"`
+	ProjectDir string `yaml:"project-dir"`
+	Reason     string `yaml:"reason,omitempty"`
+}
+
+type ProjectClaimDetector func(projectDir, requestedPlugin string) (*ProjectClaim, error)
+
+var projectClaimDetector ProjectClaimDetector
+
+func SetProjectClaimDetector(detector ProjectClaimDetector) {
+	projectClaimDetector = detector
+}
+
+type CurrentContextDiscovery struct {
+	CWD               string
+	ComposeProjectDir string
+	Claim             *ProjectClaim
+	Context           *Context
+}
+
 func DiscoverCurrentContext() (*Context, error) {
-	cwd, err := os.Getwd()
+	result, err := DiscoverCurrentContextForPlugin("")
 	if err != nil {
 		return nil, err
 	}
-	return FindLocalContextByProjectDir(cwd)
+	return result.Context, nil
+}
+
+func DiscoverCurrentContextForPlugin(requestedPlugin string) (CurrentContextDiscovery, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return CurrentContextDiscovery{}, err
+	}
+
+	result := CurrentContextDiscovery{CWD: cwd}
+	projectDir := FindComposeProjectRoot(cwd)
+	if projectDir == "" {
+		return result, nil
+	}
+	result.ComposeProjectDir = projectDir
+
+	if projectClaimDetector == nil {
+		return result, nil
+	}
+	claim, err := projectClaimDetector(projectDir, requestedPlugin)
+	if err != nil {
+		return result, err
+	}
+	if claim == nil || strings.TrimSpace(claim.Plugin) == "" {
+		return result, nil
+	}
+	if strings.TrimSpace(claim.ProjectDir) == "" {
+		claim.ProjectDir = projectDir
+	}
+	result.Claim = claim
+
+	ctx, err := FindLocalContextByProjectDirAndPlugin(projectDir, claim.Plugin)
+	if err != nil {
+		return result, err
+	}
+	result.Context = ctx
+	return result, nil
 }

--- a/pkg/helpers/helper_test.go
+++ b/pkg/helpers/helper_test.go
@@ -24,7 +24,7 @@ func TestGetContextFromArgs(t *testing.T) {
 			name:         "no context flag",
 			args:         []string{"arg1", "arg2"},
 			expectedArgs: []string{"arg1", "arg2"},
-			expectedCtx:  "default",
+			expectedCtx:  "",
 		},
 		{
 			name:         "separate --context flag",

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -40,9 +40,13 @@ func OpenURL(url string) error {
 // for cobra commands that allow arbitrary args to facilitate passing flags to other commands
 // strip out sitectl's context flag from the args if it was passed
 func GetContextFromArgs(cmd *cobra.Command, args []string) ([]string, string, error) {
-	siteCtx, err := cmd.Root().PersistentFlags().GetString("context")
-	if err != nil {
-		return nil, "", err
+	siteCtx := ""
+	if flags := cmd.Root().PersistentFlags(); flags.Lookup("context") != nil && flags.Changed("context") {
+		value, err := flags.GetString("context")
+		if err != nil {
+			return nil, "", err
+		}
+		siteCtx = value
 	}
 
 	// remove --context flag from the args if it exists

--- a/pkg/plugin/project_discovery.go
+++ b/pkg/plugin/project_discovery.go
@@ -1,0 +1,280 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/libops/sitectl/pkg/config"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v3"
+)
+
+type ProjectDiscoveryFunc func(projectDir string) (*config.ProjectClaim, error)
+
+type ComposeProjectDiscovery struct {
+	RequiredServices          []string
+	ForbiddenServices         []string
+	RequiredComposerPackages  []string
+	ForbiddenComposerPackages []string
+	ComposerFiles             []string
+	Reason                    string
+}
+
+type projectDetectionResult struct {
+	Claimed    bool   `yaml:"claimed"`
+	Plugin     string `yaml:"plugin,omitempty"`
+	ProjectDir string `yaml:"project-dir,omitempty"`
+	Reason     string `yaml:"reason,omitempty"`
+}
+
+func (s *SDK) SetProjectDiscovery(discovery ProjectDiscoveryFunc) {
+	if s == nil {
+		return
+	}
+	s.projectDiscovery = discovery
+}
+
+func (s *SDK) SetComposeProjectDiscovery(spec ComposeProjectDiscovery) {
+	if s == nil {
+		return
+	}
+	s.SetProjectDiscovery(func(projectDir string) (*config.ProjectClaim, error) {
+		return claimComposeProject(s.Metadata.Name, projectDir, spec)
+	})
+}
+
+func (s *SDK) GetProjectDetectionCommand() *cobra.Command {
+	var projectDir string
+	cmd := &cobra.Command{
+		Use:    "__detect-project",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			claim, err := s.detectOwnProject(projectDir)
+			if err != nil {
+				return err
+			}
+			result := projectDetectionResult{Claimed: claim != nil}
+			if claim != nil {
+				result.Plugin = claim.Plugin
+				result.ProjectDir = claim.ProjectDir
+				result.Reason = claim.Reason
+			}
+			data, err := yaml.Marshal(result)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&projectDir, "path", ".", "Compose project directory to inspect.")
+	return cmd
+}
+
+func (s *SDK) detectOwnProject(projectDir string) (*config.ProjectClaim, error) {
+	if s == nil || s.projectDiscovery == nil {
+		return nil, nil
+	}
+	projectDir = filepath.Clean(strings.TrimSpace(projectDir))
+	if projectDir == "" {
+		projectDir = "."
+	}
+	if resolved, err := filepath.Abs(projectDir); err == nil {
+		projectDir = resolved
+	}
+	claim, err := s.projectDiscovery(projectDir)
+	if err != nil || claim == nil {
+		return claim, err
+	}
+	if strings.TrimSpace(claim.Plugin) == "" {
+		claim.Plugin = s.Metadata.Name
+	}
+	if strings.TrimSpace(claim.ProjectDir) == "" {
+		claim.ProjectDir = projectDir
+	}
+	return claim, nil
+}
+
+func (s *SDK) detectProjectOwner(projectDir, requestedPlugin string) (*config.ProjectClaim, error) {
+	if claim, err := s.detectOwnProject(projectDir); err != nil {
+		return nil, err
+	} else if claimSupportsRequestedPlugin(claim, requestedPlugin) {
+		return claim, nil
+	}
+	return DetectProjectOwner(projectDir, requestedPlugin)
+}
+
+func DetectProjectOwner(projectDir, requestedPlugin string) (*config.ProjectClaim, error) {
+	projectDir = filepath.Clean(strings.TrimSpace(projectDir))
+	if projectDir == "" {
+		return nil, nil
+	}
+	if resolved, err := filepath.Abs(projectDir); err == nil {
+		projectDir = resolved
+	}
+
+	installed := DiscoverInstalledLightweight()
+	sort.SliceStable(installed, func(i, j int) bool {
+		return installed[i].Name < installed[j].Name
+	})
+	for _, discovered := range installed {
+		if strings.TrimSpace(requestedPlugin) != "" && discovered.Name != requestedPlugin && !ContextPluginSupports(discovered.Name, requestedPlugin) {
+			continue
+		}
+		claim, ok := detectInstalledPluginProject(discovered, projectDir)
+		if !ok || !claimSupportsRequestedPlugin(claim, requestedPlugin) {
+			continue
+		}
+		return claim, nil
+	}
+	return nil, nil
+}
+
+func detectInstalledPluginProject(discovered InstalledPlugin, projectDir string) (*config.ProjectClaim, bool) {
+	cmd := exec.Command(discovered.Path, "__detect-project", "--path", projectDir) // #nosec G204 -- plugin path comes from sitectl plugin discovery and is invoked only for its hidden project detector.
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, false
+	}
+	var result projectDetectionResult
+	if err := yaml.Unmarshal(output, &result); err != nil || !result.Claimed {
+		return nil, false
+	}
+	pluginName := strings.TrimSpace(result.Plugin)
+	if pluginName == "" {
+		pluginName = discovered.Name
+	}
+	claim := &config.ProjectClaim{
+		Plugin:     pluginName,
+		ProjectDir: strings.TrimSpace(result.ProjectDir),
+		Reason:     strings.TrimSpace(result.Reason),
+	}
+	if claim.ProjectDir == "" {
+		claim.ProjectDir = projectDir
+	}
+	return claim, true
+}
+
+func claimSupportsRequestedPlugin(claim *config.ProjectClaim, requestedPlugin string) bool {
+	if claim == nil {
+		return false
+	}
+	requestedPlugin = strings.TrimSpace(requestedPlugin)
+	if requestedPlugin == "" {
+		return true
+	}
+	return ContextPluginSupports(strings.TrimSpace(claim.Plugin), requestedPlugin)
+}
+
+func claimComposeProject(pluginName, projectDir string, spec ComposeProjectDiscovery) (*config.ProjectClaim, error) {
+	services := stringSet(config.DetectComposeServices(projectDir))
+	if len(spec.RequiredServices) > 0 && !containsAll(services, spec.RequiredServices) {
+		return nil, nil
+	}
+	if containsAny(services, spec.ForbiddenServices) {
+		return nil, nil
+	}
+
+	packages, err := readComposerPackages(projectDir, spec.ComposerFiles)
+	if err != nil {
+		return nil, err
+	}
+	if len(spec.RequiredComposerPackages) > 0 && !containsAll(packages, spec.RequiredComposerPackages) {
+		return nil, nil
+	}
+	if containsAny(packages, spec.ForbiddenComposerPackages) {
+		return nil, nil
+	}
+	if len(spec.RequiredServices) == 0 && len(spec.RequiredComposerPackages) == 0 {
+		return nil, nil
+	}
+
+	reason := strings.TrimSpace(spec.Reason)
+	if reason == "" {
+		reason = defaultProjectDiscoveryReason(spec)
+	}
+	return &config.ProjectClaim{
+		Plugin:     strings.TrimSpace(pluginName),
+		ProjectDir: projectDir,
+		Reason:     reason,
+	}, nil
+}
+
+func defaultProjectDiscoveryReason(spec ComposeProjectDiscovery) string {
+	parts := make([]string, 0, 2)
+	if len(spec.RequiredServices) > 0 {
+		parts = append(parts, "services "+strings.Join(spec.RequiredServices, ", "))
+	}
+	if len(spec.RequiredComposerPackages) > 0 {
+		parts = append(parts, "composer packages "+strings.Join(spec.RequiredComposerPackages, ", "))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func readComposerPackages(projectDir string, files []string) (map[string]bool, error) {
+	if len(files) == 0 {
+		files = []string{
+			"composer.json",
+			"drupal/rootfs/var/www/drupal/composer.json",
+		}
+	}
+	packages := map[string]bool{}
+	for _, rel := range files {
+		path := filepath.Join(projectDir, filepath.Clean(rel))
+		data, err := os.ReadFile(path) // #nosec G304 -- path is constrained to plugin-declared composer files inside the selected project.
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read composer file %q: %w", path, err)
+		}
+		var doc struct {
+			Require    map[string]json.RawMessage `json:"require"`
+			RequireDev map[string]json.RawMessage `json:"require-dev"`
+		}
+		if err := json.Unmarshal(data, &doc); err != nil {
+			return nil, fmt.Errorf("parse composer file %q: %w", path, err)
+		}
+		for name := range doc.Require {
+			packages[strings.TrimSpace(name)] = true
+		}
+		for name := range doc.RequireDev {
+			packages[strings.TrimSpace(name)] = true
+		}
+	}
+	return packages, nil
+}
+
+func stringSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = true
+		}
+	}
+	return out
+}
+
+func containsAll(haystack map[string]bool, needles []string) bool {
+	for _, needle := range needles {
+		if !haystack[strings.TrimSpace(needle)] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAny(haystack map[string]bool, needles []string) bool {
+	for _, needle := range needles {
+		if haystack[strings.TrimSpace(needle)] {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugin/project_discovery_test.go
+++ b/pkg/plugin/project_discovery_test.go
@@ -1,0 +1,48 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestComposeProjectDiscoveryClaimsMatchingService(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yml"), []byte("services:\n  ojs:\n    image: ojs:latest\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(docker-compose.yml) error = %v", err)
+	}
+
+	claim, err := claimComposeProject("ojs", projectDir, ComposeProjectDiscovery{
+		RequiredServices: []string{"ojs"},
+	})
+	if err != nil {
+		t.Fatalf("claimComposeProject() error = %v", err)
+	}
+	if claim == nil {
+		t.Fatal("expected project claim")
+	}
+	if claim.Plugin != "ojs" {
+		t.Fatalf("expected ojs claim, got %q", claim.Plugin)
+	}
+}
+
+func TestComposeProjectDiscoveryRejectsForbiddenComposerPackage(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "docker-compose.yml"), []byte("services:\n  drupal:\n    image: drupal:latest\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(docker-compose.yml) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "composer.json"), []byte(`{"require":{"drupal/islandora":"^2"}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(composer.json) error = %v", err)
+	}
+
+	claim, err := claimComposeProject("drupal", projectDir, ComposeProjectDiscovery{
+		RequiredServices:          []string{"drupal"},
+		ForbiddenComposerPackages: []string{"drupal/islandora"},
+	})
+	if err != nil {
+		t.Fatalf("claimComposeProject() error = %v", err)
+	}
+	if claim != nil {
+		t.Fatalf("expected no Drupal claim for Islandora composer package, got %+v", claim)
+	}
+}

--- a/pkg/plugin/sdk.go
+++ b/pkg/plugin/sdk.go
@@ -61,6 +61,7 @@ type SDK struct {
 	componentDefs     []component.Definition
 	deploys           []RegisteredDeploy
 	deployRootCmd     *cobra.Command
+	projectDiscovery  ProjectDiscoveryFunc
 	hasConverge       bool
 	hasSet            bool
 	hasValidate       bool
@@ -91,6 +92,8 @@ func NewSDK(metadata Metadata) *SDK {
 	}
 
 	sdk.addCommonFlags()
+	sdk.RootCmd.AddCommand(sdk.GetProjectDetectionCommand())
+	config.SetProjectClaimDetector(sdk.detectProjectOwner)
 	return sdk
 }
 
@@ -119,8 +122,10 @@ func (s *SDK) setupLogging(cmd *cobra.Command) error {
 
 	// Store config for plugin use.
 	s.Config.LogLevel = ll
-	if s.RootCmd.PersistentFlags().Lookup("context") != nil {
+	if s.RootCmd.PersistentFlags().Lookup("context") != nil && cmd.Flags().Changed("context") {
 		s.Config.Context, _ = cmd.Flags().GetString("context")
+	} else {
+		s.Config.Context = ""
 	}
 
 	return nil
@@ -133,12 +138,7 @@ func (s *SDK) addCommonFlags() {
 		ll = "INFO"
 	}
 	s.RootCmd.PersistentFlags().String("log-level", ll, "The logging level for the command")
-	c, err := config.Current()
-	if err != nil {
-		slog.Warn("unable to fetch current context, defaulting to empty", "err", err)
-	}
-
-	s.RootCmd.PersistentFlags().String("context", c, "The sitectl context to use. See sitectl config --help for more info")
+	s.RootCmd.PersistentFlags().String("context", "", "The sitectl context to use. See sitectl config --help for more info")
 }
 
 // AddCommand adds a subcommand to the plugin
@@ -244,8 +244,11 @@ func (s *SDK) GetContext() (*config.Context, error) {
 
 	// Use explicit --context if provided, otherwise resolve current context
 	contextName := s.Config.Context
+	if contextName == "default" {
+		contextName = cfg.CurrentContext
+	}
 	if contextName == "" {
-		contextName, err = config.Current()
+		contextName, err = config.CurrentForPluginWithDiagnostics(s.Metadata.Name, os.Stderr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve current context: %w", err)
 		}


### PR DESCRIPTION
Add plugin-owned project discovery so sitectl can ask installed plugins whether a Compose project belongs to them before falling back to the configured default context.

Expose an SDK project detector and hidden __detect-project command, wire context resolution through claimed cwd projects, and print stderr diagnostics describing whether cwd or the default context was selected.

Keep explicit --context authoritative and preserve plugin validation so direct plugin invocations fail when the fallback default context is owned by an incompatible plugin.

Also add IIIF-specific component dispositions used by the ISLE plugin for cantaloupe/triplet selection.